### PR TITLE
enable the proper resolution of `cloudflare:*` imports

### DIFF
--- a/fixtures/cloudflare-dev-module-resolution/entry-workerd.ts
+++ b/fixtures/cloudflare-dev-module-resolution/entry-workerd.ts
@@ -2,6 +2,8 @@ const allowedPaths = new Set([
   '/require-ext',
   '/require-no-ext',
   '/require-json',
+  '/cloudflare-imports',
+
   '/third-party/react',
   '/third-party/remix',
   '/third-party/discord-api-types',

--- a/fixtures/cloudflare-dev-module-resolution/index.test.ts
+++ b/fixtures/cloudflare-dev-module-resolution/index.test.ts
@@ -31,3 +31,15 @@ describe('basic module resolution', () => {
     });
   });
 });
+
+describe('Cloudflare specific module resolution', () => {
+  test('imports from `cloudflare:*`', async () => {
+    const output = await fetchOutputFromViteDevServer('/cloudflare-imports');
+
+    expect(output).toEqual({
+      '(cloudflare:workers) WorkerEntrypoint.name': 'WorkerEntrypoint',
+      '(cloudflare:workers) DurableObject.name': 'DurableObjectBase',
+      '(cloudflare:sockets) typeof connect': 'function',
+    });
+  });
+});

--- a/fixtures/cloudflare-dev-module-resolution/src/cloudflare-imports.ts
+++ b/fixtures/cloudflare-dev-module-resolution/src/cloudflare-imports.ts
@@ -1,0 +1,8 @@
+import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
+import { connect } from 'cloudflare:sockets';
+
+export default {
+  '(cloudflare:workers) WorkerEntrypoint.name': WorkerEntrypoint.name,
+  '(cloudflare:workers) DurableObject.name': DurableObject.name,
+  '(cloudflare:sockets) typeof connect': typeof connect,
+};

--- a/fixtures/cloudflare-dev-module-resolution/tsconfig.json
+++ b/fixtures/cloudflare-dev-module-resolution/tsconfig.json
@@ -14,8 +14,7 @@
     "declarationMap": true
   },
   "include": [
-    "entry-workerd.ts",
-    ".eslintrc.js",
+    "src",
   ],
   "exclude": ["src/client"]
 }

--- a/packages/vite-environment-provider-cloudflare/src/worker/index.ts
+++ b/packages/vite-environment-provider-cloudflare/src/worker/index.ts
@@ -75,6 +75,14 @@ async function getModuleRunner(env: Env) {
       root: env.ROOT,
       transport: {
         fetchModule: async (...args) => {
+          const moduleId = args[0];
+          if (moduleId.startsWith('cloudflare:')) {
+            return {
+              externalize: moduleId,
+              type: 'builtin',
+            };
+          }
+
           const response = await env.__viteFetchModule.fetch(
             new Request('http://localhost', {
               method: 'POST',


### PR DESCRIPTION
resolves #15 

___


Regarding `workerd:*` imports, from what I can tell from looking [into the `workerd` repo](https://github.com/cloudflare/workerd/blob/76198481858fce538e4efa2783c3844e38149227/src/cloudflare/tsconfig.json#L28-L30):
```js
"cloudflare:*": ["./*"],
"cloudflare-internal:*": ["./internal/*"],
"workerd:compatibility-flags": ["./internal/compatibility-flags.d.ts"]
```

both the `cloudflare-internal:` and `workerd:` scopes seem to be internal ones, so not something to expose to users... so I am wondering, do they need to actually be handled here? (can code from `cloudflare:*` import from `cloudflare-internal:*` for example)?
